### PR TITLE
feat: add Twig template for contact content element

### DIFF
--- a/src/Content/Contact.php
+++ b/src/Content/Contact.php
@@ -13,11 +13,9 @@ declare(strict_types=1);
 
 namespace Nutshell\ContactElement\Content;
 
-use Contao\Config;
 use Contao\ContentElement;
 use Contao\FilesModel;
 use Contao\StringUtil;
-use Contao\Validator;
 use Contao\System;
 
 class Contact extends ContentElement
@@ -34,39 +32,28 @@ class Contact extends ContentElement
      */
     protected function compile(): void
     {
-
-        // Add the static files URL to images
-        if ($staticUrl = System::getContainer()->get('contao.assets.files_context')->getStaticUrl()) {
-            $path = Config::get('uploadPath') . '/';
-        }
-
-        $this->Template->text = StringUtil::encodeEmail($this->text);
         $this->Template->addContactImage = false;
 
         // Add an image
         if ($this->addContactImage && $this->singleSRC) {
             $objModel = FilesModel::findByUuid($this->singleSRC);
 
-            if ($objModel !== null && is_file(System::getContainer()->getParameter('kernel.project_dir') . '/' . $objModel->path)) {
-                $this->singleSRC = $objModel->path;
-                $this->overwriteMeta = ($this->alt || $this->imageTitle || $this->caption);
-
+            if (null !== $objModel && is_file(System::getContainer()->getParameter('kernel.project_dir').'/'.$objModel->path)) {
                 $figure = System::getContainer()
-                ->get('contao.image.studio')
-                ->createFigureBuilder()
-                ->from($objModel->path)
-                ->setSize($this->size)
-                ->setMetadata($this->objModel->getOverwriteMetadata())
-                ->enableLightbox((bool) $this->fullsize)
-                ->buildIfResourceExists();
+                    ->get('contao.image.studio')
+                    ->createFigureBuilder()
+                    ->from($objModel->path)
+                    ->setSize($this->size)
+                    ->setOverwriteMetadata($this->objModel->getOverwriteMetadata())
+                    ->enableLightbox((bool) $this->fullsize)
+                    ->buildIfResourceExists()
+                ;
 
-                if (null !== $figure)
-                {
+                if (null !== $figure) {
                     $figure->applyLegacyTemplateData($this->Template, $this->imagemargin, $this->floating);
+                    $this->Template->addContactImage = true;
                 }
             }
-
-            $this->Template->addContactImage = true;
         }
 
         // Encode contact email

--- a/src/Resources/contao/templates/ce_contact.html.twig
+++ b/src/Resources/contao/templates/ce_contact.html.twig
@@ -1,12 +1,13 @@
+{% set hasImage = addContactImage and picture is defined %}
+
 <div class="{{ class }} block"{{ cssID|raw }}{% if style %} style="{{ style }}"{% endif %}>
 
   {% if headline %}
     <{{ hl }}>{{ headline }}</{{ hl }}>
   {% endif %}
 
-  {% if addContactImage %}
+  {% if hasImage %}
     <figure class="contact__image{{ floatClass }}"{% if margin %} style="{{ margin }}"{% endif %}>
-
       {% if href %}
         <a href="{{ href }}"{% if linkTitle %} title="{{ linkTitle }}"{% endif %}{{ attributes|raw }}>
       {% endif %}
@@ -20,7 +21,6 @@
       {% if caption %}
         <figcaption class="caption">{{ caption }}</figcaption>
       {% endif %}
-
     </figure>
   {% endif %}
 

--- a/src/Resources/contao/templates/ce_contact.html.twig
+++ b/src/Resources/contao/templates/ce_contact.html.twig
@@ -35,7 +35,7 @@
       {% endif %}
 
       {% if contactDescription %}
-        <div class="contact__description">{{ contactDescription|raw }}</div>
+        <div class="contact__description">{{ contactDescription|default|sanitize_html('contao')|csp_inline_styles|insert_tag_raw }}</div>
       {% endif %}
 
       {% if contactPhone %}

--- a/src/Resources/contao/templates/ce_contact.html.twig
+++ b/src/Resources/contao/templates/ce_contact.html.twig
@@ -1,0 +1,53 @@
+<div class="{{ class }} block"{{ cssID|raw }}{% if style %} style="{{ style }}"{% endif %}>
+
+  {% if headline %}
+    <{{ hl }}>{{ headline }}</{{ hl }}>
+  {% endif %}
+
+  {% if addContactImage %}
+    <figure class="contact__image{{ floatClass }}"{% if margin %} style="{{ margin }}"{% endif %}>
+
+      {% if href %}
+        <a href="{{ href }}"{% if linkTitle %} title="{{ linkTitle }}"{% endif %}{{ attributes|raw }}>
+      {% endif %}
+
+      {{ include('@Contao/picture_default.html.twig', picture, false) }}
+
+      {% if href %}
+        </a>
+      {% endif %}
+
+      {% if caption %}
+        <figcaption class="caption">{{ caption }}</figcaption>
+      {% endif %}
+
+    </figure>
+  {% endif %}
+
+  <div class="contact__details">
+    <div class="inside">
+      {% if contactName %}
+        <div class="contact__name">{{ contactName }}</div>
+      {% endif %}
+
+      {% if contactPosition %}
+        <div class="contact__position">{{ contactPosition }}</div>
+      {% endif %}
+
+      {% if contactDescription %}
+        <div class="contact__description">{{ contactDescription|raw }}</div>
+      {% endif %}
+
+      {% if contactPhone %}
+        <div class="contact__phone">{{ contactPhone }}</div>
+      {% endif %}
+
+      {% if contactEmail %}
+        <div class="contact__email">
+          <a href="{{ contactEmailLink }}" title="{{ contactName }}">{{ contactEmail }}</a>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+
+</div>


### PR DESCRIPTION
## Summary
- add ce_contact.html.twig for Contao Twig rendering
- replace legacy PHP picture include behavior with Twig include
- keep markup structure aligned with existing ce_contact.html5 template

## Test
- deployed in c57 and validated backend element creation + frontend HTTP 200
- verified no Twig Unknown insert function error for contact element